### PR TITLE
dev chat: add plan and implement modes

### DIFF
--- a/api/src/api/controller/chat.py
+++ b/api/src/api/controller/chat.py
@@ -76,6 +76,7 @@ class CreateChatRequest(BaseModel):
     chat_id: Optional[str] = None
     vm_name: Optional[str] = None
     work_dir: Optional[str] = None
+    post_hooks: Optional[list] = None
 
 
 class CreateChatResponse(BaseModel):
@@ -88,6 +89,7 @@ class SendMessageRequest(BaseModel):
     bot_name: Optional[str] = None
     vm_name: Optional[str] = None
     work_dir: Optional[str] = None
+    post_hooks: Optional[list] = None
 
 
 class StopChatRequest(BaseModel):
@@ -127,11 +129,16 @@ async def post_create_chat(req: CreateChatRequest, request: Request):
         "id": generate_message_id(),
     })
 
-    await chat_service.create_chat(
+    chat = await chat_service.create_chat(
         user_id,
         messages=[user_msg],
         chat_id=chat_id,
     )
+
+    if req.post_hooks:
+        chat.post_hooks = req.post_hooks
+        from storage.repository import chat as chat_repo
+        await chat_repo.save_chat_by_id(chat)
 
     _send_chat_message(chat_id, bot_name=req.bot_name, user_id=user_id, vm_name=req.vm_name, work_dir=req.work_dir)
     return CreateChatResponse(chat_id=chat_id)
@@ -155,6 +162,8 @@ async def post_send_message(req: SendMessageRequest, request: Request):
     })
     chat.messages.append(user_msg)
     chat.interrupted = False
+    if req.post_hooks is not None:
+        chat.post_hooks = req.post_hooks
 
     from storage.repository import chat as chat_repo
     await chat_repo.save_chat_by_id(chat)

--- a/api/src/api/controller/chat.py
+++ b/api/src/api/controller/chat.py
@@ -41,7 +41,7 @@ def _get_celery_app():
     return app
 
 
-def _send_chat_message(chat_id: str, bot_name: str = None, user_id: int = None, vm_name: str = None, work_dir: str = None):
+def _send_chat_message(chat_id: str, bot_name: str = None, user_id: int = None, vm_name: str = None, work_dir: str = None, post_hooks: list = None):
     """Send a message to trigger the worker for a chat.
 
     Uses SQS when SQS_QUEUE_URL is set (production/Lambda).
@@ -56,6 +56,8 @@ def _send_chat_message(chat_id: str, bot_name: str = None, user_id: int = None, 
         payload["vm_name"] = vm_name
     if work_dir:
         payload["work_dir"] = work_dir
+    if post_hooks:
+        payload["post_hooks"] = post_hooks
 
     queue_url = os.environ.get("SQS_QUEUE_URL")
     if queue_url:
@@ -67,7 +69,7 @@ def _send_chat_message(chat_id: str, bot_name: str = None, user_id: int = None, 
         return
 
     app = _get_celery_app()
-    app.send_task("worker.tasks.process_chat", args=[chat_id], kwargs={"bot_name": bot_name, "user_id": user_id, "vm_name": vm_name, "work_dir": work_dir})
+    app.send_task("worker.tasks.process_chat", args=[chat_id], kwargs={"bot_name": bot_name, "user_id": user_id, "vm_name": vm_name, "work_dir": work_dir, "post_hooks": post_hooks})
 
 
 class CreateChatRequest(BaseModel):
@@ -135,12 +137,7 @@ async def post_create_chat(req: CreateChatRequest, request: Request):
         chat_id=chat_id,
     )
 
-    if req.post_hooks:
-        chat.post_hooks = req.post_hooks
-        from storage.repository import chat as chat_repo
-        await chat_repo.save_chat_by_id(chat)
-
-    _send_chat_message(chat_id, bot_name=req.bot_name, user_id=user_id, vm_name=req.vm_name, work_dir=req.work_dir)
+    _send_chat_message(chat_id, bot_name=req.bot_name, user_id=user_id, vm_name=req.vm_name, work_dir=req.work_dir, post_hooks=req.post_hooks)
     return CreateChatResponse(chat_id=chat_id)
 
 
@@ -162,13 +159,11 @@ async def post_send_message(req: SendMessageRequest, request: Request):
     })
     chat.messages.append(user_msg)
     chat.interrupted = False
-    if req.post_hooks is not None:
-        chat.post_hooks = req.post_hooks
 
     from storage.repository import chat as chat_repo
     await chat_repo.save_chat_by_id(chat)
 
-    _send_chat_message(req.chat_id, bot_name=req.bot_name, user_id=user_id, vm_name=req.vm_name, work_dir=req.work_dir)
+    _send_chat_message(req.chat_id, bot_name=req.bot_name, user_id=user_id, vm_name=req.vm_name, work_dir=req.work_dir, post_hooks=req.post_hooks)
     return {"ok": True}
 
 

--- a/cli/src/yagent/commands/chat/dev.py
+++ b/cli/src/yagent/commands/chat/dev.py
@@ -1,4 +1,5 @@
 import os
+import re
 import subprocess
 import sys
 import click
@@ -34,13 +35,21 @@ def _stream_and_handle(chat_id: str, display_manager: DisplayManager, last_index
     return last_index, True
 
 
-def _build_prompt(todo: dict) -> str:
+def _build_prompt(todo: dict, mode: str | None = None) -> str:
     parts = [f"Task: {todo['name']}"]
     if todo.get('desc'):
         parts.append(todo['desc'])
-    if todo.get('progress'):
-        parts.append(todo['progress'])
-    parts.append("\nWhen finishing a plan, always include the plan file path in your response so the user can review it.")
+    if mode == 'plan':
+        parts.append("\nYou are in plan mode. Create a detailed implementation plan but do NOT write any code.")
+        parts.append("When finishing a plan, always include the plan file path in your response so the user can review it.")
+    elif mode == 'implement':
+        if todo.get('progress'):
+            parts.append(f"\nImplementation plan: {todo['progress']}")
+        parts.append("\nYou are in implement mode. Follow the plan and implement the changes.")
+    else:
+        if todo.get('progress'):
+            parts.append(todo['progress'])
+        parts.append("\nWhen finishing a plan, always include the plan file path in your response so the user can review it.")
     return "\n".join(parts)
 
 
@@ -133,9 +142,10 @@ def _remove_worktree(git_root: str, todo_id: str):
 @click.option('--no-worktree', is_flag=True, help='Skip worktree creation, use cwd')
 @click.option('--clean', is_flag=True, help='Remove worktree and exit')
 @click.option('--message', '-m', default=None, help='Continue message (default: "Continue working on this task.")')
+@click.option('--mode', type=click.Choice(['plan', 'implement']), default=None, help='Plan or implement mode')
 @click.option('--bot', '-b', default='claude-code', help='Bot name')
 @click.option('--vm', default='default', help='VM name')
-def chat_dev(todo_id: str, clear: bool, follow: bool, no_worktree: bool, clean: bool, message: str, bot: str, vm: str):
+def chat_dev(todo_id: str, clear: bool, follow: bool, no_worktree: bool, clean: bool, message: str, mode: str, bot: str, vm: str):
     """Start a dev chat session linked to a todo item."""
     # Handle --clean: remove worktree and exit
     if clean:
@@ -172,7 +182,7 @@ def chat_dev(todo_id: str, clear: bool, follow: bool, no_worktree: bool, clean: 
         })
         click.echo(f"Resumed chat {chat_id}")
     else:
-        prompt = _build_prompt(todo)
+        prompt = _build_prompt(todo, mode)
         resp = api_request("POST", "/api/chat", json={
             "prompt": prompt, "bot_name": bot, "work_dir": work_dir,
         })
@@ -218,7 +228,31 @@ def chat_dev(todo_id: str, clear: bool, follow: bool, no_worktree: bool, clean: 
         if interrupted:
             break
 
-    # 5. Auto commit and PR (worktree only)
+    # 5. Plan mode: update todo with plan file path from last assistant message
+    if mode == 'plan':
+        try:
+            resp = api_request("GET", "/api/chat/detail", params={"chat_id": chat_id})
+            messages = resp.json().get("messages", [])
+            # Find plan file path from last assistant message
+            plan_path = None
+            for msg in reversed(messages):
+                if msg.get("role") == "assistant":
+                    content = msg.get("content", "")
+                    # Look for file path in the message
+                    paths = re.findall(r'(/[^\s\n`"\']+\.md)', content)
+                    if paths:
+                        plan_path = paths[-1]
+                    break
+            if plan_path:
+                api_request("POST", "/api/todo/update", json={
+                    "todo_id": todo_id, "progress": plan_path,
+                })
+                click.echo(f"Plan saved to todo progress: {plan_path}")
+        except Exception as e:
+            click.echo(f"Failed to update todo with plan: {e}", err=True)
+        return
+
+    # 6. Auto commit and PR (worktree only)
     if not no_worktree:
         try:
             _commit_and_pr(work_dir, todo, todo_id)

--- a/cli/src/yagent/commands/chat/dev.py
+++ b/cli/src/yagent/commands/chat/dev.py
@@ -1,5 +1,4 @@
 import os
-import re
 import subprocess
 import sys
 import click
@@ -53,6 +52,15 @@ def _build_prompt(todo: dict, mode: str | None = None) -> str:
     return "\n".join(parts)
 
 
+def _build_post_hooks(todo: dict, todo_id: str, mode: str | None, no_worktree: bool) -> list | None:
+    hooks = []
+    if mode == 'plan':
+        hooks.append({"type": "save_plan_to_todo", "todo_id": todo_id})
+    if not no_worktree:
+        hooks.append({"type": "commit_and_pr", "todo_id": todo_id, "todo_name": todo['name'], "todo_desc": todo.get('desc', '')})
+    return hooks or None
+
+
 def _git_root() -> str:
     return subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
 
@@ -90,37 +98,6 @@ def _apply_symlinks(git_root: str, worktree_path: str):
             if not os.path.exists(target):
                 os.makedirs(os.path.dirname(target), exist_ok=True)
                 os.symlink(src, target)
-
-
-def _commit_and_pr(work_dir: str, todo: dict, todo_id: str):
-    """Stage, commit, push, and create PR for worktree changes."""
-    branch = f"worktree-{todo_id}"
-    git = ["git", "-C", work_dir]
-
-    # Check for changes
-    status = subprocess.run(git + ["status", "--porcelain"], capture_output=True, text=True)
-    if not status.stdout.strip():
-        click.echo("No changes to commit.")
-        return
-
-    # Stage, commit, push
-    subprocess.check_call(git + ["add", "-A"])
-    subprocess.check_call(git + ["commit", "-m", todo["name"]])
-    click.echo("Committed changes.")
-
-    subprocess.check_call(git + ["push", "-u", "origin", branch])
-    click.echo(f"Pushed branch {branch}.")
-
-    # Create PR (may already exist)
-    desc = todo.get("desc") or ""
-    result = subprocess.run(
-        ["gh", "pr", "create", "--head", branch, "--title", todo["name"], "--body", desc],
-        cwd=work_dir, capture_output=True, text=True,
-    )
-    if result.returncode == 0:
-        click.echo(f"PR created: {result.stdout.strip()}")
-    else:
-        click.echo(f"PR creation skipped: {result.stderr.strip()}")
 
 
 def _remove_worktree(git_root: str, todo_id: str):
@@ -173,18 +150,21 @@ def chat_dev(todo_id: str, clear: bool, follow: bool, no_worktree: bool, clean: 
 
     # 3. Resume vs new chat
     chat_ids = todo.get('chat_ids') or []
+    post_hooks = _build_post_hooks(todo, todo_id, mode, no_worktree)
 
     if chat_ids and not clear:
         chat_id = chat_ids[-1]
         prompt = message or "Continue working on this task."
         api_request("POST", "/api/chat/message", json={
             "chat_id": chat_id, "prompt": prompt, "bot_name": bot, "work_dir": work_dir,
+            "post_hooks": post_hooks,
         })
         click.echo(f"Resumed chat {chat_id}")
     else:
         prompt = _build_prompt(todo, mode)
         resp = api_request("POST", "/api/chat", json={
             "prompt": prompt, "bot_name": bot, "work_dir": work_dir,
+            "post_hooks": post_hooks,
         })
         chat_id = resp.json()["chat_id"]
 
@@ -227,34 +207,3 @@ def chat_dev(todo_id: str, clear: bool, follow: bool, no_worktree: bool, clean: 
         last_index, interrupted = _stream_and_handle(chat_id, display_manager, last_index)
         if interrupted:
             break
-
-    # 5. Plan mode: update todo with plan file path from last assistant message
-    if mode == 'plan':
-        try:
-            resp = api_request("GET", "/api/chat/detail", params={"chat_id": chat_id})
-            messages = resp.json().get("messages", [])
-            # Find plan file path from last assistant message
-            plan_path = None
-            for msg in reversed(messages):
-                if msg.get("role") == "assistant":
-                    content = msg.get("content", "")
-                    # Look for file path in the message
-                    paths = re.findall(r'(/[^\s\n`"\']+\.md)', content)
-                    if paths:
-                        plan_path = paths[-1]
-                    break
-            if plan_path:
-                api_request("POST", "/api/todo/update", json={
-                    "todo_id": todo_id, "progress": plan_path,
-                })
-                click.echo(f"Plan saved to todo progress: {plan_path}")
-        except Exception as e:
-            click.echo(f"Failed to update todo with plan: {e}", err=True)
-        return
-
-    # 6. Auto commit and PR (worktree only)
-    if not no_worktree:
-        try:
-            _commit_and_pr(work_dir, todo, todo_id)
-        except Exception as e:
-            click.echo(f"Auto commit/PR failed: {e}", err=True)

--- a/storage/src/storage/dto/chat.py
+++ b/storage/src/storage/dto/chat.py
@@ -130,6 +130,7 @@ class Chat:
     work_dir: Optional[str] = None
     interrupted: bool = False
     running: bool = False
+    post_hooks: Optional[List[Dict]] = None
 
     @classmethod
     def from_dict(cls, data: Dict) -> 'Chat':
@@ -150,6 +151,7 @@ class Chat:
             work_dir=data.get('work_dir'),
             interrupted=data.get('interrupted', False),
             running=data.get('running', False),
+            post_hooks=data.get('post_hooks'),
         )
 
     def to_dict(self) -> Dict:
@@ -177,6 +179,8 @@ class Chat:
             result['interrupted'] = self.interrupted
         if self.running:
             result['running'] = self.running
+        if self.post_hooks:
+            result['post_hooks'] = self.post_hooks
         return result
 
     def update_messages(self, messages: List[Message]) -> None:

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -54,6 +54,7 @@ build/Release
 
 # Dependency directories
 
+node_modules
 node_modules/
 jspm_packages/
 

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,1 +1,0 @@
-/Users/roy/luohy15/code/y-agent-937493/../y-agent/web/node_modules

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,0 +1,1 @@
+/Users/roy/luohy15/code/y-agent-937493/../y-agent/web/node_modules

--- a/worker/handler.py
+++ b/worker/handler.py
@@ -27,8 +27,9 @@ def lambda_handler(event, context):
     user_id = body.get("user_id")
     vm_name = body.get("vm_name")
     work_dir = body.get("work_dir")
+    post_hooks = body.get("post_hooks")
 
-    print(f"[worker] SQS trigger for chat {chat_id} bot_name={bot_name} user_id={user_id} vm_name={vm_name} work_dir={work_dir}")
+    print(f"[worker] SQS trigger for chat {chat_id} bot_name={bot_name} user_id={user_id} vm_name={vm_name} work_dir={work_dir} post_hooks={post_hooks}")
 
-    asyncio.run(run_chat(user_id, chat_id, bot_name=bot_name, vm_name=vm_name, work_dir=work_dir))
+    asyncio.run(run_chat(user_id, chat_id, bot_name=bot_name, vm_name=vm_name, work_dir=work_dir, post_hooks=post_hooks))
     return {"status": "ok", "chat_id": chat_id}

--- a/worker/src/worker/runner.py
+++ b/worker/src/worker/runner.py
@@ -25,9 +25,9 @@ def check_interrupted(chat_id: str) -> bool:
     return c.interrupted if c else False
 
 
-def _run_post_hooks(chat, user_id: int) -> None:
-    """Execute post-completion hooks stored on the chat."""
-    for hook in chat.post_hooks:
+def _run_post_hooks(chat, user_id: int, post_hooks: list) -> None:
+    """Execute post-completion hooks."""
+    for hook in post_hooks:
         hook_type = hook.get("type")
         try:
             if hook_type == "commit_and_pr":
@@ -93,9 +93,9 @@ def _hook_save_plan_to_todo(chat, hook: dict, user_id: int) -> None:
         logger.info("save_plan_to_todo: saved plan path {} to todo {}", plan_path, todo_id)
 
 
-async def run_chat(user_id: int, chat_id: str, bot_name: str = None, vm_name: str = None, work_dir: str = None) -> None:
-    """Execute a chat round. bot_name, user_id, vm_name, and work_dir are passed from the queue message."""
-    logger.info("run_chat start chat_id={} bot_name={} user_id={} vm_name={} work_dir={}", chat_id, bot_name, user_id, vm_name, work_dir)
+async def run_chat(user_id: int, chat_id: str, bot_name: str = None, vm_name: str = None, work_dir: str = None, post_hooks: list = None) -> None:
+    """Execute a chat round. bot_name, user_id, vm_name, work_dir, and post_hooks are passed from the queue message."""
+    logger.info("run_chat start chat_id={} bot_name={} user_id={} vm_name={} work_dir={} post_hooks={}", chat_id, bot_name, user_id, vm_name, work_dir, post_hooks)
 
     # Load chat from DB (with user_id access check)
     chat = await chat_service.get_chat(user_id, chat_id)
@@ -125,8 +125,9 @@ async def run_chat(user_id: int, chat_id: str, bot_name: str = None, vm_name: st
             fresh.running = False
             await chat_repo.save_chat_by_id(fresh)
             # Execute post hooks if chat completed (not interrupted)
-            if not fresh.interrupted and fresh.post_hooks:
-                _run_post_hooks(fresh, user_id)
+            if not fresh.interrupted and post_hooks:
+                logger.info("Running {} post hooks for chat {}", len(post_hooks), chat_id)
+                _run_post_hooks(fresh, user_id, post_hooks)
 
 
 async def _run_chat_agent_loop(chat, chat_id: str, user_id: int, bot_config, vm_name: str = None, work_dir: str = None) -> None:

--- a/worker/src/worker/runner.py
+++ b/worker/src/worker/runner.py
@@ -1,6 +1,8 @@
 """Run a single chat through the agent loop, writing messages to DB."""
 
 import os
+import re
+import subprocess
 from typing import List
 
 from loguru import logger
@@ -21,6 +23,74 @@ def message_callback(chat_id: str, message: Message):
 def check_interrupted(chat_id: str) -> bool:
     c = chat_service.get_chat_by_id_sync(chat_id)
     return c.interrupted if c else False
+
+
+def _run_post_hooks(chat, user_id: int) -> None:
+    """Execute post-completion hooks stored on the chat."""
+    for hook in chat.post_hooks:
+        hook_type = hook.get("type")
+        try:
+            if hook_type == "commit_and_pr":
+                _hook_commit_and_pr(chat.work_dir, hook)
+            elif hook_type == "save_plan_to_todo":
+                _hook_save_plan_to_todo(chat, hook, user_id)
+            else:
+                logger.warning("Unknown post_hook type: {}", hook_type)
+        except Exception as e:
+            logger.exception("Post hook {} failed: {}", hook_type, e)
+
+
+def _hook_commit_and_pr(work_dir: str, hook: dict) -> None:
+    """Stage, commit, push, and create PR."""
+    todo_name = hook.get("todo_name", "auto commit")
+    todo_desc = hook.get("todo_desc", "")
+    todo_id = hook.get("todo_id", "")
+    branch = f"worktree-{todo_id}" if todo_id else None
+
+    git = ["git", "-C", work_dir]
+
+    status = subprocess.run(git + ["status", "--porcelain"], capture_output=True, text=True)
+    if not status.stdout.strip():
+        logger.info("commit_and_pr: no changes to commit")
+        return
+
+    subprocess.check_call(git + ["add", "-A"])
+    subprocess.check_call(git + ["commit", "-m", todo_name])
+    logger.info("commit_and_pr: committed")
+
+    if branch:
+        subprocess.check_call(git + ["push", "-u", "origin", branch])
+        logger.info("commit_and_pr: pushed branch {}", branch)
+
+        result = subprocess.run(
+            ["gh", "pr", "create", "--head", branch, "--title", todo_name, "--body", todo_desc],
+            cwd=work_dir, capture_output=True, text=True,
+        )
+        if result.returncode == 0:
+            logger.info("commit_and_pr: PR created: {}", result.stdout.strip())
+        else:
+            logger.info("commit_and_pr: PR skipped: {}", result.stderr.strip())
+
+
+def _hook_save_plan_to_todo(chat, hook: dict, user_id: int) -> None:
+    """Extract plan file path from last assistant message and save to todo progress."""
+    from storage.service import todo as todo_service
+    todo_id = hook.get("todo_id")
+    if not todo_id:
+        return
+
+    plan_path = None
+    for msg in reversed(chat.messages):
+        if msg.role == "assistant":
+            content = msg.content if isinstance(msg.content, str) else ""
+            paths = re.findall(r'(/[^\s\n`"\']+\.md)', content)
+            if paths:
+                plan_path = paths[-1]
+            break
+
+    if plan_path:
+        todo_service.update_todo(user_id, todo_id, progress=plan_path)
+        logger.info("save_plan_to_todo: saved plan path {} to todo {}", plan_path, todo_id)
 
 
 async def run_chat(user_id: int, chat_id: str, bot_name: str = None, vm_name: str = None, work_dir: str = None) -> None:
@@ -54,6 +124,9 @@ async def run_chat(user_id: int, chat_id: str, bot_name: str = None, vm_name: st
         if fresh:
             fresh.running = False
             await chat_repo.save_chat_by_id(fresh)
+            # Execute post hooks if chat completed (not interrupted)
+            if not fresh.interrupted and fresh.post_hooks:
+                _run_post_hooks(fresh, user_id)
 
 
 async def _run_chat_agent_loop(chat, chat_id: str, user_id: int, bot_config, vm_name: str = None, work_dir: str = None) -> None:

--- a/worker/src/worker/tasks.py
+++ b/worker/src/worker/tasks.py
@@ -9,10 +9,10 @@ from worker.runner import run_chat
 
 
 @app.task(name="worker.tasks.process_chat")
-def process_chat(chat_id: str, bot_name: str = None, user_id: int = None, vm_name: str = None, work_dir: str = None):
+def process_chat(chat_id: str, bot_name: str = None, user_id: int = None, vm_name: str = None, work_dir: str = None, post_hooks: list = None):
     """Run the agent loop for a chat."""
     try:
-        asyncio.run(run_chat(user_id, chat_id, bot_name=bot_name, vm_name=vm_name, work_dir=work_dir))
+        asyncio.run(run_chat(user_id, chat_id, bot_name=bot_name, vm_name=vm_name, work_dir=work_dir, post_hooks=post_hooks))
         logger.info("Finished chat {}", chat_id)
     except Exception as e:
         logger.exception("Chat {} failed: {}", chat_id, e)


### PR DESCRIPTION
Add --mode option to dev command with two modes:
1. plan mode: runs dev chat in plan mode, when finished updates todo desc and puts plan file path in progress
2. implement mode: works with --clear, reads the plan from progress and starts implementation