### PR TITLE
Switch file directory to follow chat selection

### DIFF
--- a/api/src/api/controller/file.py
+++ b/api/src/api/controller/file.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import dataclasses
 import fnmatch
 import json
 import mimetypes
@@ -28,15 +29,17 @@ class _CmdRunner(Tool):
     async def execute(self, arguments):
         pass
 
-async def _exec(user_id: int, cmd: list[str], timeout: float = 10, vm_name: str = None) -> str:
+async def _exec(user_id: int, cmd: list[str], timeout: float = 10, vm_name: str = None, work_dir: str = None) -> str:
     vm_config = resolve_vm_config(user_id, vm_name)
+    if work_dir:
+        vm_config = dataclasses.replace(vm_config, work_dir=work_dir)
     runner = _CmdRunner(vm_config)
     return await runner.run_cmd(cmd, timeout=timeout)
 
 
-async def _get_vscode_excludes(user_id: int, vm_name: str, key: str) -> list[str]:
+async def _get_vscode_excludes(user_id: int, vm_name: str, key: str, work_dir: str = None) -> list[str]:
     try:
-        raw = await _exec(user_id, ["cat", ".vscode/settings.json"], vm_name=vm_name)
+        raw = await _exec(user_id, ["cat", ".vscode/settings.json"], vm_name=vm_name, work_dir=work_dir)
         settings = json.loads(raw)
         excludes = settings.get(key, {})
         return [pat.removeprefix("**/") for pat, enabled in excludes.items() if enabled is True]
@@ -45,12 +48,12 @@ async def _get_vscode_excludes(user_id: int, vm_name: str, key: str) -> list[str
 
 
 @router.get("/list")
-async def list_files(request: Request, path: str = Query("."), vm_name: str = Query(None)):
+async def list_files(request: Request, path: str = Query("."), vm_name: str = Query(None), work_dir: str = Query(None)):
     user_id = _get_user_id(request)
-    excludes = await _get_vscode_excludes(user_id, vm_name, "files.exclude")
+    excludes = await _get_vscode_excludes(user_id, vm_name, "files.exclude", work_dir=work_dir)
     logger.info("list_files excludes: {}", excludes)
     # ls -1apL: one per line, show dirs with /, show hidden, dereference symlinks
-    output = await _exec(user_id, ["ls", "-1apL", path], vm_name=vm_name)
+    output = await _exec(user_id, ["ls", "-1apL", path], vm_name=vm_name, work_dir=work_dir)
     entries = []
     for line in output.strip().splitlines():
         if not line or line == "./" or line == "../":
@@ -69,14 +72,16 @@ async def list_files(request: Request, path: str = Query("."), vm_name: str = Qu
 
 
 @router.get("/read")
-async def read_file(request: Request, path: str = Query(...), vm_name: str = Query(None)):
+async def read_file(request: Request, path: str = Query(...), vm_name: str = Query(None), work_dir: str = Query(None)):
     user_id = _get_user_id(request)
-    content = await _exec(user_id, ["cat", path], vm_name=vm_name)
+    content = await _exec(user_id, ["cat", path], vm_name=vm_name, work_dir=work_dir)
     return {"path": path, "content": content}
 
 
-async def _exec_bytes(user_id: int, cmd: list[str], timeout: float = 10, vm_name: str = None) -> bytes:
+async def _exec_bytes(user_id: int, cmd: list[str], timeout: float = 10, vm_name: str = None, work_dir: str = None) -> bytes:
     vm_config = resolve_vm_config(user_id, vm_name)
+    if work_dir:
+        vm_config = dataclasses.replace(vm_config, work_dir=work_dir)
     if not vm_config.api_token:
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -88,21 +93,21 @@ async def _exec_bytes(user_id: int, cmd: list[str], timeout: float = 10, vm_name
         return stdout or b""
     # For remote VMs, read via base64 encoding
     import base64
-    b64 = await _exec(user_id, ["base64", cmd[-1]], timeout=timeout, vm_name=vm_name)
+    b64 = await _exec(user_id, ["base64", cmd[-1]], timeout=timeout, vm_name=vm_name, work_dir=work_dir)
     return base64.b64decode(b64)
 
 
 @router.get("/search")
-async def search_files(request: Request, q: str = Query(...), path: str = Query("."), vm_name: str = Query(None)):
+async def search_files(request: Request, q: str = Query(...), path: str = Query("."), vm_name: str = Query(None), work_dir: str = Query(None)):
     user_id = _get_user_id(request)
-    excludes = await _get_vscode_excludes(user_id, vm_name, "search.exclude")
+    excludes = await _get_vscode_excludes(user_id, vm_name, "search.exclude", work_dir=work_dir)
     # Build find command with exclude args from vscode settings
     find_cmd = ["find", path, "-maxdepth", "8", "-type", "f"]
     for pat in excludes:
         find_cmd += ["-not", "-path", f"*/{pat}/*" if not pat.startswith("*") else pat]
     find_cmd += ["-iname", f"*{q}*"]
     logger.info("search_files cmd: {}", find_cmd)
-    output = await _exec(user_id, find_cmd, timeout=10, vm_name=vm_name)
+    output = await _exec(user_id, find_cmd, timeout=10, vm_name=vm_name, work_dir=work_dir)
     files = []
     for line in output.strip().splitlines():
         if not line or len(files) >= 50:
@@ -120,9 +125,9 @@ class MoveRequest(BaseModel):
 
 
 @router.post("/move")
-async def move_files(request: Request, body: MoveRequest, vm_name: str = Query(None)):
+async def move_files(request: Request, body: MoveRequest, vm_name: str = Query(None), work_dir: str = Query(None)):
     user_id = _get_user_id(request)
-    await _exec(user_id, ["mv", *body.sources, body.dest_dir], vm_name=vm_name)
+    await _exec(user_id, ["mv", *body.sources, body.dest_dir], vm_name=vm_name, work_dir=work_dir)
     return {"sources": body.sources, "dest_dir": body.dest_dir, "success": True}
 
 
@@ -135,6 +140,7 @@ async def upload_file(
     file: UploadFile = File(...),
     dest_dir: str = Form(...),
     vm_name: str = Form(None),
+    work_dir: str = Form(None),
 ):
     user_id = _get_user_id(request)
     content = await file.read(_MAX_UPLOAD_BYTES + 1)
@@ -145,10 +151,12 @@ async def upload_file(
     dest_path = f"{dest_dir}/{filename}"
 
     vm_config = resolve_vm_config(user_id, vm_name)
+    if work_dir:
+        vm_config = dataclasses.replace(vm_config, work_dir=work_dir)
     if not vm_config.api_token:
         # Local: write directly to disk
-        work_dir = os.path.expanduser(vm_config.work_dir) if vm_config.work_dir else "."
-        full_path = os.path.normpath(os.path.join(work_dir, dest_path))
+        effective_dir = os.path.expanduser(vm_config.work_dir) if vm_config.work_dir else "."
+        full_path = os.path.normpath(os.path.join(effective_dir, dest_path))
         os.makedirs(os.path.dirname(full_path), exist_ok=True)
         with open(full_path, "wb") as f:
             f.write(content)
@@ -163,8 +171,8 @@ async def upload_file(
 
 
 @router.get("/raw")
-async def raw_file(request: Request, path: str = Query(...), vm_name: str = Query(None)):
+async def raw_file(request: Request, path: str = Query(...), vm_name: str = Query(None), work_dir: str = Query(None)):
     user_id = _get_user_id(request)
-    data = await _exec_bytes(user_id, ["cat", path], timeout=30, vm_name=vm_name)
+    data = await _exec_bytes(user_id, ["cat", path], timeout=30, vm_name=vm_name, work_dir=work_dir)
     mime, _ = mimetypes.guess_type(path)
     return Response(content=data, media_type=mime or "application/octet-stream")

--- a/api/src/api/controller/terminal.py
+++ b/api/src/api/controller/terminal.py
@@ -1,5 +1,7 @@
 """Terminal endpoint — run commands via local_exec/ssh_exec."""
 
+import dataclasses
+
 from fastapi import APIRouter, HTTPException, Query, Request
 
 from agent.config import resolve_vm_config
@@ -17,7 +19,7 @@ async def _run_cmd(vm_config, cmd: list[str], timeout: float = 300) -> str:
 
 
 @router.post("/run")
-async def run_command(request: Request, vm_name: str = Query(None)):
+async def run_command(request: Request, vm_name: str = Query(None), work_dir: str = Query(None)):
     user_id = request.state.user_id
     body = await request.json()
     cmd = body.get("command", "").strip()
@@ -25,6 +27,8 @@ async def run_command(request: Request, vm_name: str = Query(None)):
         raise HTTPException(status_code=400, detail="Empty command")
 
     vm_config = resolve_vm_config(user_id, vm_name)
+    if work_dir:
+        vm_config = dataclasses.replace(vm_config, work_dir=work_dir)
 
     try:
         result = await _run_cmd(vm_config, ["bash", "-c", cmd])

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,7 +39,7 @@ export default function App() {
   const [chatWorkDir, setChatWorkDir] = useState<string | null>(null);
   const [chatListRefreshKey, setChatListRefreshKey] = useState(0);
   const currentVmWorkDir = vmList.find(v => v.name === (selectedVM || "default"))?.work_dir;
-  const workDirMismatch = !!(selectedChatId && chatWorkDir && currentVmWorkDir && chatWorkDir !== currentVmWorkDir);
+  const effectiveWorkDir = (selectedChatId && chatWorkDir) ? chatWorkDir : currentVmWorkDir;
   const [chatListWidth, setChatListWidth] = useState(() => {
     const saved = localStorage.getItem("chatListWidth");
     return saved ? parseInt(saved, 10) : 220;
@@ -186,7 +186,7 @@ export default function App() {
           `}
           style={{ width: sidebarWidth }}
         >
-          <FileTree isLoggedIn={auth.isLoggedIn} onSelectFile={handleOpenFile} vmName={selectedVM} workDir={vmList.find(v => v.name === (selectedVM || "default"))?.work_dir} />
+          <FileTree isLoggedIn={auth.isLoggedIn} onSelectFile={handleOpenFile} vmName={selectedVM} workDir={effectiveWorkDir} />
           <div
             className="hidden md:block absolute top-0 right-0 w-1 h-full cursor-col-resize hover:bg-sol-blue/40 active:bg-sol-blue/60 z-10"
             onPointerDown={handleResizeStart}
@@ -196,11 +196,11 @@ export default function App() {
         <div className="flex-1 flex flex-col min-w-0 min-h-0">
           {/* Right top: FileViewer (kept mounted, hidden via CSS to preserve scroll state) */}
           <div className={`${chatMaximize && !chatHide ? "hidden" : chatHide ? "flex-1" : "h-2/5"} min-h-0 overflow-hidden`}>
-            <FileViewer openFiles={openFiles} activeFile={activeFile} onSelectFile={setActiveFile} onCloseFile={handleCloseFile} onReorderFiles={setOpenFiles} vmName={selectedVM} />
+            <FileViewer openFiles={openFiles} activeFile={activeFile} onSelectFile={setActiveFile} onCloseFile={handleCloseFile} onReorderFiles={setOpenFiles} vmName={selectedVM} workDir={effectiveWorkDir} />
           </div>
           {/* Toolbar (always visible) */}
           <div className="flex items-center justify-end gap-1.5 sm:gap-1 px-3 py-1 sm:py-0.5 border-t border-sol-base02 bg-sol-base03 shrink-0">
-            {!chatHide && <span className={`font-mono text-sm sm:text-xs truncate mr-auto flex items-center gap-1 p-2 sm:p-1 ${workDirMismatch ? "text-sol-yellow" : "text-sol-base01"}`} title={(selectedChatId ? chatWorkDir : currentVmWorkDir) || ""}><svg className="w-5 h-5 sm:w-3.5 sm:h-3.5 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M1 3.5A1.5 1.5 0 0 1 2.5 2h3.879a1.5 1.5 0 0 1 1.06.44l1.122 1.12A1.5 1.5 0 0 0 9.62 4H13.5A1.5 1.5 0 0 1 15 5.5v7a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 1 12.5v-9z"/></svg><span className="hidden sm:inline truncate">{selectedChatId ? chatWorkDir : currentVmWorkDir}</span>{workDirMismatch && <span className="sm:hidden">!</span>}{workDirMismatch && <span className="hidden sm:inline">(mismatch)</span>}</span>}
+            {!chatHide && <span className="font-mono text-sm sm:text-xs truncate mr-auto flex items-center gap-1 p-2 sm:p-1 text-sol-base01" title={effectiveWorkDir || ""}><svg className="w-5 h-5 sm:w-3.5 sm:h-3.5 shrink-0" viewBox="0 0 16 16" fill="currentColor"><path d="M1 3.5A1.5 1.5 0 0 1 2.5 2h3.879a1.5 1.5 0 0 1 1.06.44l1.122 1.12A1.5 1.5 0 0 0 9.62 4H13.5A1.5 1.5 0 0 1 15 5.5v7a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 1 12.5v-9z"/></svg><span className="hidden sm:inline truncate">{effectiveWorkDir}</span></span>}
             {!chatHide && (
               <>
                 {/* Tab switcher */}
@@ -281,11 +281,11 @@ export default function App() {
               <div className="flex-1 min-w-0 min-h-0 flex flex-col overflow-hidden relative">
                 {/* Chat (kept mounted, toggled via CSS) */}
                 <div className={`absolute inset-0 flex flex-col ${bottomTab === "chat" ? "" : "invisible pointer-events-none"}`}>
-                  <ChatView isLoggedIn={auth.isLoggedIn} gsiReady={auth.gsiReady} chatId={selectedChatId} onChatCreated={handleChatCreated} onClear={() => setSelectedChatId(null)} vmName={selectedVM} vmWorkDir={currentVmWorkDir} onWorkDirChange={setChatWorkDir} onComplete={() => setChatListRefreshKey((k) => k + 1)} onOpenFile={handleOpenFile} />
+                  <ChatView isLoggedIn={auth.isLoggedIn} gsiReady={auth.gsiReady} chatId={selectedChatId} onChatCreated={handleChatCreated} onClear={() => setSelectedChatId(null)} vmName={selectedVM} onWorkDirChange={setChatWorkDir} onComplete={() => setChatListRefreshKey((k) => k + 1)} onOpenFile={handleOpenFile} />
                 </div>
                 {/* Terminal (kept mounted, toggled via CSS) */}
                 <div className={`absolute inset-0 flex flex-col ${bottomTab === "terminal" ? "" : "invisible pointer-events-none"}`}>
-                  <TerminalView isLoggedIn={auth.isLoggedIn} vmName={selectedVM} />
+                  <TerminalView isLoggedIn={auth.isLoggedIn} vmName={selectedVM} workDir={effectiveWorkDir} />
                 </div>
               </div>
               {/* Desktop: chat list panel (hidden with chat) */}
@@ -323,7 +323,7 @@ export default function App() {
           </div>
         </div>
       </div>
-      <FileSearchDialog open={fileSearchOpen} onClose={() => setFileSearchOpen(false)} onSelectFile={handleOpenFile} vmName={selectedVM} openFiles={openFiles} />
+      <FileSearchDialog open={fileSearchOpen} onClose={() => setFileSearchOpen(false)} onSelectFile={handleOpenFile} vmName={selectedVM} workDir={effectiveWorkDir} openFiles={openFiles} />
     </div>
   );
 }

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -12,13 +12,12 @@ interface ChatViewProps {
   isLoggedIn: boolean;
   gsiReady?: boolean;
   vmName?: string | null;
-  vmWorkDir?: string;
   onWorkDirChange?: (workDir: string | null) => void;
   onComplete?: () => void;
   onOpenFile?: (path: string) => void;
 }
 
-export default function ChatView({ chatId, onChatCreated, onClear, isLoggedIn, gsiReady, vmName, vmWorkDir, onWorkDirChange, onComplete, onOpenFile }: ChatViewProps) {
+export default function ChatView({ chatId, onChatCreated, onClear, isLoggedIn, gsiReady, vmName, onWorkDirChange, onComplete, onOpenFile }: ChatViewProps) {
   const { mutate } = useSWRConfig();
   const [messages, setMessages] = useState<Message[]>([]);
   const [completed, setCompleted] = useState(false);
@@ -177,14 +176,14 @@ export default function ChatView({ chatId, onChatCreated, onClear, isLoggedIn, g
       await authFetch(`${API}/api/chat/message`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ chat_id: chatId, prompt: text, ...(vmName ? { vm_name: vmName } : {}) }),
+        body: JSON.stringify({ chat_id: chatId, prompt: text, ...(vmName ? { vm_name: vmName } : {}), ...(chatWorkDir ? { work_dir: chatWorkDir } : {}) }),
       });
       setFollowUp("");
       connectSSE(chatId, idxRef.current);
     } finally {
       setSending(false);
     }
-  }, [followUp, sending, chatId, vmName, connectSSE]);
+  }, [followUp, sending, chatId, vmName, chatWorkDir, connectSSE]);
 
   const createChat = useCallback(async () => {
     const text = newPrompt.trim();
@@ -295,7 +294,7 @@ export default function ChatView({ chatId, onChatCreated, onClear, isLoggedIn, g
           <span className="hidden sm:inline text-sol-base01 font-mono ml-auto">Esc / Ctrl+C to stop</span>
         </div>
       )}
-      {completed && chatWorkDir && vmWorkDir && chatWorkDir === vmWorkDir ? (
+      {completed ? (
         <ChatInput
           ref={inputRef}
           value={followUp}
@@ -309,11 +308,6 @@ export default function ChatView({ chatId, onChatCreated, onClear, isLoggedIn, g
             <button onClick={shareChat} className={`ml-auto font-mono cursor-pointer px-3 py-1 sm:px-2 sm:py-0.5 rounded text-sm sm:text-xs font-semibold ${shareLabel === "copied!" ? "bg-sol-green text-sol-base03" : "bg-sol-base02 text-sol-base01"}`}>{shareLabel}</button>
           </>}
         />
-      ) : completed ? (
-        <div className="mx-4 border-t border-sol-base02 shrink-0 px-4 py-3 flex items-center gap-3 text-sm sm:text-xs text-sol-base01">
-          {processDetailButtons}
-          <button onClick={shareChat} className={`ml-auto font-mono cursor-pointer px-3 py-1 sm:px-2 sm:py-0.5 rounded text-sm sm:text-xs font-semibold ${shareLabel === "copied!" ? "bg-sol-green text-sol-base03" : "bg-sol-base02 text-sol-base01"}`}>{shareLabel}</button>
-        </div>
       ) : null}
     </div>
   );

--- a/web/src/components/FileSearchDialog.tsx
+++ b/web/src/components/FileSearchDialog.tsx
@@ -6,11 +6,12 @@ interface FileSearchDialogProps {
   onClose: () => void;
   onSelectFile: (path: string) => void;
   vmName?: string | null;
+  workDir?: string;
   openFiles?: string[];
 }
 
-export default function FileSearchDialog({ open, onClose, onSelectFile, vmName, openFiles = [] }: FileSearchDialogProps) {
-  const vmQuery = vmName ? `&vm_name=${encodeURIComponent(vmName)}` : "";
+export default function FileSearchDialog({ open, onClose, onSelectFile, vmName, workDir, openFiles = [] }: FileSearchDialogProps) {
+  const vmQuery = (vmName ? `&vm_name=${encodeURIComponent(vmName)}` : "") + (workDir ? `&work_dir=${encodeURIComponent(workDir)}` : "");
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<string[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);

--- a/web/src/components/FileTree.tsx
+++ b/web/src/components/FileTree.tsx
@@ -228,7 +228,7 @@ interface FileTreeProps {
 }
 
 export default function FileTree({ isLoggedIn, onSelectFile, vmName, workDir }: FileTreeProps) {
-  const vmQuery = vmName ? `&vm_name=${encodeURIComponent(vmName)}` : "";
+  const vmQuery = (vmName ? `&vm_name=${encodeURIComponent(vmName)}` : "") + (workDir ? `&work_dir=${encodeURIComponent(workDir)}` : "");
   const [roots, setRoots] = useState<FileEntry[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -335,6 +335,7 @@ export default function FileTree({ isLoggedIn, onSelectFile, vmName, workDir }: 
         form.append("file", file);
         form.append("dest_dir", destDir);
         if (vmName) form.append("vm_name", vmName);
+        if (workDir) form.append("work_dir", workDir);
         await authFetch(`${API}/api/file/upload`, { method: "POST", body: form });
       }
     } finally {
@@ -344,7 +345,7 @@ export default function FileTree({ isLoggedIn, onSelectFile, vmName, workDir }: 
     // Refresh affected directories
     const refresh = dirRefreshMapRef.current.get(destDir) ?? dirRefreshMapRef.current.get(".");
     if (refresh) refresh();
-  }, [vmName]);
+  }, [vmName, workDir]);
 
   const handleBackgroundClick = useCallback((e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {

--- a/web/src/components/FileViewer.tsx
+++ b/web/src/components/FileViewer.tsx
@@ -19,6 +19,7 @@ interface FileViewerProps {
   onCloseFile: (path: string) => void;
   onReorderFiles: (files: string[]) => void;
   vmName?: string | null;
+  workDir?: string;
 }
 
 const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "bmp", "svg", "webp", "ico"]);
@@ -168,9 +169,9 @@ function MarkdownPreview({ content }: { content: string }) {
   );
 }
 
-export default function FileViewer({ openFiles, activeFile, onSelectFile, onCloseFile, onReorderFiles, vmName }: FileViewerProps) {
+export default function FileViewer({ openFiles, activeFile, onSelectFile, onCloseFile, onReorderFiles, vmName, workDir }: FileViewerProps) {
   const { mutate } = useSWRConfig();
-  const vmQuery = vmName ? `&vm_name=${encodeURIComponent(vmName)}` : "";
+  const vmQuery = (vmName ? `&vm_name=${encodeURIComponent(vmName)}` : "") + (workDir ? `&work_dir=${encodeURIComponent(workDir)}` : "");
   const [cache, setCache] = useState<Record<string, FileCache>>({});
   const [mdPreview, setMdPreview] = useState<Record<string, boolean>>({});
   const [zoom, setZoom] = useState(100);

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -4,9 +4,10 @@ import { API, authFetch } from "../api";
 interface TerminalViewProps {
   isLoggedIn: boolean;
   vmName: string | null;
+  workDir?: string;
 }
 
-export default function TerminalView({ isLoggedIn, vmName }: TerminalViewProps) {
+export default function TerminalView({ isLoggedIn, vmName, workDir }: TerminalViewProps) {
   const [output, setOutput] = useState("");
   const [input, setInput] = useState("");
   const [running, setRunning] = useState(false);
@@ -32,6 +33,7 @@ export default function TerminalView({ isLoggedIn, vmName }: TerminalViewProps) 
 
     const params = new URLSearchParams();
     if (vmName) params.set("vm_name", vmName);
+    if (workDir) params.set("work_dir", workDir);
 
     try {
       const res = await authFetch(`${API}/api/terminal/run?${params}`, {


### PR DESCRIPTION
## Summary
- File panel (FileTree, FileViewer, FileSearchDialog, TerminalView) now switches work directory when selecting a different chat
- API file/terminal endpoints accept optional `work_dir` query parameter to override VM config
- Removed `workDirMismatch` warning since the directory now follows chat automatically
- Follow-up input always shows when chat is completed (no longer gated on work_dir match)

## Test plan
- [ ] Select different chats and verify FileTree shows the correct directory
- [ ] Open files from FileTree and verify FileViewer reads from the correct work_dir
- [ ] Use file search (Cmd+P) and verify results come from the chat's work_dir
- [ ] Run terminal commands and verify they execute in the chat's work_dir
- [ ] Create a new chat (no chatId) and verify it falls back to VM default work_dir
- [ ] Send follow-up messages and verify they use the chat's work_dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)